### PR TITLE
feat: satori run script.sh --stdout

### DIFF
--- a/src/satoricli/bundler.py
+++ b/src/satoricli/bundler.py
@@ -50,23 +50,10 @@ def make_bundle(playbook: Path, base_dir: Path):
     return obj
 
 
-SCRIPT_INTERPRETERS = {
-    ".sh": "bash",
-    ".py": "python3",
-    ".rb": "ruby",
-    ".pl": "perl",
-    ".js": "node",
-    ".ps1": "powershell -File",
-    ".bat": "cmd /c",
-    ".cmd": "cmd /c",
-}
-
-
 def make_script_bundle(script_path: Path, image: str = "debian") -> io.BytesIO:
-    interpreter = SCRIPT_INTERPRETERS.get(script_path.suffix, "bash")
     playbook = yaml.dump({
         "settings": {"image": image},
-        "execute": [f"{interpreter} {script_path.name}"],
+        "execute": [f"chmod +x {script_path.name} && ./{script_path.name}"],
     })
     obj = io.BytesIO()
     with ZipFile(obj, "x") as zf:

--- a/src/satoricli/bundler.py
+++ b/src/satoricli/bundler.py
@@ -1,6 +1,7 @@
 import io
+import stat
 from pathlib import Path
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
 
 import yaml
 from satorici.validator import is_import_group, is_input_group, is_test
@@ -53,11 +54,13 @@ def make_bundle(playbook: Path, base_dir: Path):
 def make_script_bundle(script_path: Path, image: str = "debian") -> io.BytesIO:
     playbook = yaml.dump({
         "settings": {"image": image},
-        "execute": [f"chmod +x {script_path.name} && ./{script_path.name}"],
+        "execute": [f"./{script_path.name}"],
     })
     obj = io.BytesIO()
     with ZipFile(obj, "x") as zf:
         zf.writestr(".satori.yml", playbook)
-        zf.write(script_path, script_path.name)
+        info = ZipInfo(script_path.name)
+        info.external_attr = (stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH) << 16
+        zf.writestr(info, script_path.read_bytes())
     obj.seek(0)
     return obj

--- a/src/satoricli/bundler.py
+++ b/src/satoricli/bundler.py
@@ -48,3 +48,29 @@ def make_bundle(playbook: Path, base_dir: Path):
 
     obj.seek(0)
     return obj
+
+
+SCRIPT_INTERPRETERS = {
+    ".sh": "bash",
+    ".py": "python3",
+    ".rb": "ruby",
+    ".pl": "perl",
+    ".js": "node",
+    ".ps1": "powershell -File",
+    ".bat": "cmd /c",
+    ".cmd": "cmd /c",
+}
+
+
+def make_script_bundle(script_path: Path, image: str = "debian") -> io.BytesIO:
+    interpreter = SCRIPT_INTERPRETERS.get(script_path.suffix, "bash")
+    playbook = yaml.dump({
+        "settings": {"image": image},
+        "execute": [f"{interpreter} {script_path.name}"],
+    })
+    obj = io.BytesIO()
+    with ZipFile(obj, "x") as zf:
+        zf.writestr(".satori.yml", playbook)
+        zf.write(script_path, script_path.name)
+    obj.seek(0)
+    return obj

--- a/src/satoricli/cli/commands/ai.py
+++ b/src/satoricli/cli/commands/ai.py
@@ -6,77 +6,8 @@ from ..utils import error_console
 from .base import BaseCommand
 
 PROMPT = """\
-You are Loop, the Satori CI assistant. Satori is an automated testing platform \
-that uses YAML playbooks to test any software, system, or network inside containers. \
-Tests run on demand, on CI (GitHub push), or on a schedule (monitors).
-
-# Setup
-On first interaction, ensure the satorici GitHub repos (playbooks, playbook-validator, \
-satori-cli, satori-docs) are cloned (--depth 1) or pulled under ~/.satori/. \
-Use these repos as your knowledge base for examples and validation rules.
-
-# Playbook Syntax
-Playbooks are YAML files with this structure:
-
-```yaml
-settings:
-  name: "Playbook Name"
-  description: "What it tests"
-  image: debian  # Docker base image
-  # Optional: timeout, cpu, memory, cron, rate, os, storage
-
-import:  # optional
-  - satori://path/to/playbook.yml
-
-test_block_name:
-  install:
-    - apt-get install -qy tool
-  run:
-    - tool --target ${{PARAM}}
-  assertReturnCode: 0
-  assertStdoutNotContains: "ERROR"
-```
-
-## Variables
-- `${{VAR}}` — user provides via `satori run -d VAR=value`
-- `${{step.stdout}}` — reference output from a previous step
-
-## Assertions (apply to the command group they're in)
-- assertReturnCode / assertReturnCodeNot (integer)
-- assertStdout / assertStderr (true|false — was there output?)
-- assertStdoutEqual / assertStdoutNotEqual (exact match)
-- assertStdoutContains / assertStdoutNotContains (substring, accepts array)
-- assertStdoutRegex / assertStdoutNotRegex (regex pattern)
-- assertStderrEqual / assertStderrNotEqual / assertStderrContains / assertStderrNotContains
-- assertStderrRegex / assertStderrNotRegex
-- assertDifferent (true|false), assertKilled (true|false)
-- setSeverity: 1-5 (1=critical, 5=info)
-
-## Inputs (parameterization & fuzzing)
-```yaml
-input:
-  - - "value1"
-    - "value2"
-run:
-  - cmd ${{input}}  # runs once per value
-```
-Supports file-based inputs (`file: dict.txt, split: "\\n"`) and mutations (`mutate: radamsa`).
-
-# Key CLI Commands
-- `satori run playbook.yml --report --output` — execute remotely (add `-d KEY=VAL` for params) and show the report and the output
-- `satori run playbook.yml --local` — execute locally
-- `satori run satori://code/semgrep.yml` — run a public playbook
-- `satori shell --image debian` — interactive dev shell
-- `satori monitor` — manage scheduled executions
-- `satori scan` — scan repos across commits
-- `satori report <id>` — view execution results
-
-# Guidelines
-- If an assertion is required, include it in the playbook.
-- Write playbooks in the current working directory unless told otherwise.
-- Prefer simple, minimal playbooks.
-- When the user describes what to test, produce a ready-to-run .yml file and provide the command to execute it.
-- Validate generated playbooks against the schemas in ~/.satori/playbook-validator.
+We are Satori and your nickname is Loop. Satori is a languaje, a CLI, a web UI, along with on a platform that scales on demand. Allows developers to launch development shells and/or executions and testing of software and systems. You can run static and/or dynamic automations that can be parametrized and fuzzed using public or custom playbooks. They can run on demand, on CI or by monitoring using a certain frequency. If you need the files, don't forget to add it to the playbook settings. 
+Satori's lenguaje allows you to test software written on any language for any operating systems. Our language allows us to test executions with open source testing playbooks and provide practical tools and interfaces to perform automated testing of software and system. This will allow you to create deterministic playbooks that will run either for regression or test driven development. Check if these public satorici Github repositories are in your $HOME/.satori directory before starting: playbooks, playbook-validator, satori-cli, satori-docs. Clone them if they are not, and then analyze them. Let me know when you are ready.
 """
 
 

--- a/src/satoricli/cli/commands/run.py
+++ b/src/satoricli/cli/commands/run.py
@@ -16,7 +16,7 @@ from rich.progress import open as progress_open
 from satorici.validator import validate_settings
 
 from satoricli.api import client
-from satoricli.bundler import make_bundle
+from satoricli.bundler import make_bundle, make_script_bundle
 from satoricli.cli.commands.scan import ScanCommand
 from satoricli.cli.utils import log
 from satoricli.validations import get_parameters, validate_parameters
@@ -39,6 +39,7 @@ from .base import BaseCommand
 from .report import ReportCommand
 
 VISIBILITY_VALUES = Literal["public", "private", "unlisted"]
+YAML_EXTENSIONS = {".yml", ".yaml"}
 
 
 def include_files(include: list[str]) -> Optional[str]:
@@ -227,6 +228,11 @@ class RunCommand(BaseCommand):
         sync.add_argument("-o", "--output", action="store_true")
         sync.add_argument("-r", "--report", action="store_true")
         sync.add_argument("-f", "--files", action="store_true")
+        sync.add_argument(
+            "--stdout",
+            action="store_true",
+            help="Wait and print only raw stdout",
+        )
         parser.add_argument(
             "--visibility", choices=get_args(VISIBILITY_VALUES), default=None
         )
@@ -266,6 +272,7 @@ class RunCommand(BaseCommand):
         output: bool,
         report: bool,
         files: bool,
+        stdout: bool,
         team: str,
         filter_tests: list,
         text_format: Literal["plain", "md"],
@@ -354,36 +361,17 @@ class RunCommand(BaseCommand):
 
             is_monitor = False
         elif (file_path := Path(path)).is_file():
-            # HOOK HERE
-            provided_var_names = set(parsed_data.keys()) if parsed_data else set()
-            env_vars = get_parameters_from_env(file_path)
-
-            if not validate_config(file_path, set(env_vars) | provided_var_names):
-                return 1
-
-            bundle = make_bundle(file_path, file_path.parent)
-            config = yaml.safe_load(file_path.read_bytes())
-
-            settings: dict[str, Any] = config.get("settings", {})
-            is_monitor = is_monitor or settings.get("cron") or settings.get("rate")
-            settings.update(cli_settings)
-
-            warn_settings(settings)
-
-            secrets = env_vars | (parsed_data or {})
-
-            if is_monitor:
-                monitor_id = new_monitor(
-                    bundle, settings, team, secrets=secrets, visibility=visibility
-                )
-            else:
+            if file_path.suffix not in YAML_EXTENSIONS:
+                image = cli_settings.pop("image", "debian")
+                bundle = make_script_bundle(file_path, image=image)
+                warn_settings(cli_settings)
                 ids = new_run(
                     path=path,
                     team=team,
                     modes=modes,
                     bundle=bundle,
-                    secrets=secrets,
-                    settings=settings,
+                    secrets=parsed_data,
+                    settings=cli_settings,
                     save_report=save_report,
                     save_output=save_output,
                     visibility=visibility,
@@ -391,6 +379,44 @@ class RunCommand(BaseCommand):
                     packet=include_files(include_list),
                     redacted=redacted,
                 )
+            else:
+                # HOOK HERE
+                provided_var_names = set(parsed_data.keys()) if parsed_data else set()
+                env_vars = get_parameters_from_env(file_path)
+
+                if not validate_config(file_path, set(env_vars) | provided_var_names):
+                    return 1
+
+                bundle = make_bundle(file_path, file_path.parent)
+                config = yaml.safe_load(file_path.read_bytes())
+
+                settings: dict[str, Any] = config.get("settings", {})
+                is_monitor = is_monitor or settings.get("cron") or settings.get("rate")
+                settings.update(cli_settings)
+
+                warn_settings(settings)
+
+                secrets = env_vars | (parsed_data or {})
+
+                if is_monitor:
+                    monitor_id = new_monitor(
+                        bundle, settings, team, secrets=secrets, visibility=visibility
+                    )
+                else:
+                    ids = new_run(
+                        path=path,
+                        team=team,
+                        modes=modes,
+                        bundle=bundle,
+                        secrets=secrets,
+                        settings=settings,
+                        save_report=save_report,
+                        save_output=save_output,
+                        visibility=visibility,
+                        clone=clone,
+                        packet=include_files(include_list),
+                        redacted=redacted,
+                    )
         elif (base := Path(path)).is_dir():
             settings = {}
             packet = make_packet(base)
@@ -476,6 +502,15 @@ class RunCommand(BaseCommand):
         elif is_monitor and kwargs["json"]:
             console.print_json(data={"monitor_id": monitor_id})
             return
+
+        if stdout:
+            wait(ids[0], True, filter_tests, text_format)
+            res = client.get(f"/outputs/{ids[0]}").json()
+            for entry in res:
+                text = entry.get("output", {}).get("stdout")
+                if text:
+                    sys.stdout.write(text)
+            return 0
 
         if sync or report or output or files:
             wait(ids[0], not report, filter_tests, text_format)


### PR DESCRIPTION
## Summary
- Non-YAML files passed to `satori run` are auto-wrapped in a playbook and executed directly (shebang is respected)
- New `--stdout` flag waits for completion and prints only raw stdout (report IDs go to stderr)
- Script is bundled in the zip with executable permissions (755) set via Python's `ZipInfo`, no `chmod` needed
- Image defaults to `debian`, overrideable with `--image`

### Usage
```sh
satori run script.sh --stdout 2>/dev/null
hola mundo
```

### Files changed
- `src/satoricli/bundler.py` — new `make_script_bundle()` function
- `src/satoricli/cli/commands/run.py` — script detection by extension, `--stdout` flag

## Test plan
- [ ] `satori run script.sh --stdout` prints only stdout
- [ ] `satori run script.sh --stdout 2>/dev/null` hides report IDs
- [ ] `satori run playbook.yml` still works as before (no regression)
- [ ] `satori run script.sh --image ubuntu:22.04 --stdout` uses custom image
- [ ] Script with shebang (`#!/usr/bin/python3`) uses correct interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)