### PR TITLE
Fix --original flag for non-public playbooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "satori-ci"
-version = "1.88.0"
+version = "1.89.0"
 description = "Satori CI - Automated Testing"
 authors = [
     {name = "Satori CI CLI", email = "info@satori.ci"},

--- a/src/satoricli/cli/commands/playbook.py
+++ b/src/satoricli/cli/commands/playbook.py
@@ -58,6 +58,9 @@ class PlaybookCommand(BaseCommand):
 
         if action == "show":
             data = client.get(f"/playbooks/{id}").json()
+            if original:
+                print(data["playbook"])
+                return 0
             list_separator = None
         # elif action == "delete":
         #     data = client.delete(f"/playbooks/{id}")


### PR DESCRIPTION
## Summary
- `--original` flag on `satori playbook <ID>` was only working for public playbooks (`satori://` URIs) — now it also works for user playbooks fetched by ID
- Bumps version to 1.89.0

## Test plan
- [ ] `satori playbook <ID>` still shows formatted output with metadata
- [ ] `satori playbook <ID> --original` prints only the raw YAML content
- [ ] `satori playbook satori://path/to/playbook.yml --original` still works as before